### PR TITLE
making footer position relative

### DIFF
--- a/css/style.less
+++ b/css/style.less
@@ -416,7 +416,7 @@ ul.breadcrumb {
 footer {
 	padding-top: 7rem;
 	bottom: 0;
-	position: absolute;
+	position: relative;
 	width: 100%;
 	height: 100px;
 


### PR DESCRIPTION
Hey team, I change the footer's position to be relative versus absolute because when it was absolute it make some of the content un-clickable if it extended over the footer. I noticed it on the Tour.html page, on desktop view, when all the accordions were open.